### PR TITLE
Bump supported Crystal version to ">= 0.32.1" in shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,6 @@ version: 0.1.0
 authors:
   - Juan Wajnerman <waj@manas.tech>
 
-crystal: 0.32.1
+crystal: ">= 0.32.1"
 
 license: MIT


### PR DESCRIPTION
That should solve issues like this: https://github.com/crystal-lang/shards/pull/462/checks?check_run_id=1698675130#step:5:10