### PR TITLE
Tweak CI

### DIFF
--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -1,6 +1,6 @@
 name: Crystal CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -3,16 +3,25 @@ name: Crystal CI
 on: [push, pull_request]
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
-    container:
-      image: crystallang/crystal
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        crystal: [latest, nightly]
+    runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: shards install
-    - name: Run tests
-      run: crystal spec
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal }}
+
+      - name: Download source
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: shards install
+
+      - name: Run specs
+        run: crystal spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: crystal
-
-# Uncomment the following if you'd like Travis to run specs and check code formatting
-# script:
-#   - crystal spec
-#   - crystal tool format --check


### PR DESCRIPTION
I've noticed that GitHub Actions are not being run on pull requests, so I've made few changes to overhaul the current CI flow.

- Removed Travis CI, since it's redundant and I can't see a good reason to keep it
- Made GitHub Actions run on pull requests in addition to normal push events
- Added job matrix to run the tests against mac/linux w/ crystal latest/nightly