### PR TITLE
Populate `VERSION` constant from `shards version`

### DIFF
--- a/src/molinillo.cr
+++ b/src/molinillo.cr
@@ -1,5 +1,5 @@
 module Molinillo
-  VERSION = "0.2.0"
+  VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
 end
 
 require "./molinillo/**"


### PR DESCRIPTION
This will make a `version` property in `shard.yml` an authoritative source of version definition.