### PR TITLE
`crystal tool format` with Crystal 1.15.0-dev

### DIFF
--- a/spec/dependency_graph/log_spec.cr
+++ b/spec/dependency_graph/log_spec.cr
@@ -24,7 +24,7 @@ end
 
 describe Molinillo::DependencyGraph::Log do
   describe "with empty log" do
-    shared_examples_for_replay ->(_g : DG) {}
+    shared_examples_for_replay ->(_g : DG) { }
   end
 
   describe "with some graph" do

--- a/spec/spec_helper/versions.cr
+++ b/spec/spec_helper/versions.cr
@@ -63,7 +63,7 @@ module Shards
         end
       end
 
-      def only_zeroes?
+      def only_zeroes?(&)
         return if empty?
         yield unless to_i? == 0
 

--- a/src/molinillo/delegates/specification_provider.cr
+++ b/src/molinillo/delegates/specification_provider.cr
@@ -62,7 +62,7 @@ module Molinillo
       # Ensures any raised {NoSuchDependencyError} has its
       # {NoSuchDependencyError#required_by} set.
       # @yield
-      private def with_no_such_dependency_error_handling
+      private def with_no_such_dependency_error_handling(&)
         yield
       rescue error : NoSuchDependencyError
         if state

--- a/src/molinillo/dependency_graph.cr
+++ b/src/molinillo/dependency_graph.cr
@@ -7,7 +7,7 @@ require "./dependency_graph/vertex"
 class Molinillo::DependencyGraph(P, R)
   # Enumerates through the vertices of the graph.
   # @return [Array<Vertex>] The graph's vertices.
-  def each
+  def each(&)
     # return vertices.values.each unless block_given?
     vertices.values.each { |v| yield v }
   end

--- a/src/molinillo/dependency_graph/log.cr
+++ b/src/molinillo/dependency_graph/log.cr
@@ -50,7 +50,7 @@ class Molinillo::DependencyGraph::Log(P, R)
 
   # Enumerates each action in the log
   # @yield [Action]
-  def each
+  def each(&)
     action = @first_action
     loop do
       break unless action

--- a/src/molinillo/modules/ui.cr
+++ b/src/molinillo/modules/ui.cr
@@ -43,7 +43,7 @@ module Molinillo
     #
     # @param [Integer] depth the current depth of the resolution process.
     # @return [void]
-    def debug(depth = 0)
+    def debug(depth = 0, &)
       if debug?
         debug_info = yield
         debug_info = debug_info.inspect unless debug_info.is_a?(String)

--- a/src/molinillo/resolution.cr
+++ b/src/molinillo/resolution.cr
@@ -674,7 +674,7 @@ module Molinillo
       # @param [Integer] depth the depth of the {#states} stack
       # @param [Proc] block a block that yields a {#to_s}
       # @return [void]
-      private def debug(depth = 0)
+      private def debug(depth = 0, &)
         resolver_ui.debug(depth) { yield }
       end
 


### PR DESCRIPTION
Crystal nightly has a couple new formatter rules enabled: https://github.com/crystal-lang/crystal/pull/14718
The changes are backwards-compatible, so Crystal 1.14.0 won't complain about the new format.