### PR TITLE
Add `REUSE` configuration

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,7 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Manas Technology Solutions
-Copyright (c) 2014 Samuel E. Giddins segiddins@segiddins.me
+Copyright (c) <year> <copyright holders>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 associated documentation files (the "Software"), to deal in the Software without restriction, including

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,7 @@
+version = 1
+
+# All original code in this repository is licensed under MIT.
+[[annotations]]
+path = ["**"]
+SPDX-FileCopyrightText = "Copyright 2020 Manas Technology Solutions."
+SPDX-License-Identifier = "MIT"


### PR DESCRIPTION
Adds `REUSE.toml` which specifies the licenses associated with different parts of this repository according to the [reuse specification](https://reuse.software/).

This article is a good introduction of the purpose and operation: https://fedoramagazine.org/beginners-guide-for-open-source-developers-for-software-licensing-with-fsfe-reuse/

There are no changes to the licenses or licensing terms. This PR is just a formal declaration of which licenses apply to which parts of the code base.

ref https://github.com/crystal-lang/crystal/pull/15992